### PR TITLE
Add state saving

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Build project
+        run: |
+          python setup.py install

--- a/animation.py
+++ b/animation.py
@@ -1,0 +1,7 @@
+import time
+
+def loading_animation():
+    animations = ['[■□□□□□□□□□]', '[■■□□□□□□□□]', '[■■■□□□□□□□]', '[■■■■□□□□□□]', '[■■■■■□□□□□]', '[■■■■■■□□□□]', '[■■■■■■■□□□]', '[■■■■■■■■□□]', '[■■■■■■■■■□]', '[■■■■■■■■■■]']
+    for i in range(20):
+        print(f"\r{animations[i % len(animations)]}", end='', flush=True)
+        time.sleep(0.1)

--- a/header.py
+++ b/header.py
@@ -1,0 +1,11 @@
+import pyfiglet
+import colorama
+from colorama import Fore, Style
+
+# Your name for copyright
+COPYRIGHT_OWNER = "Harekrishna Rai"
+
+def figlet_header():
+    ascii_art = pyfiglet.figlet_format("Snare", font = "slant")
+    print(Fore.RED + ascii_art + Style.RESET_ALL)
+    print(f"{Fore.YELLOW}Copyright © {COPYRIGHT_OWNER}{Style.RESET_ALL}")

--- a/main.py
+++ b/main.py
@@ -1,20 +1,12 @@
 #!/usr/bin/env python3
 
 import boto3
-from botocore.exceptions import ClientError
-import pyfiglet
-import time
-import os
-import colorama
-from colorama import Fore, Back, Style
-import random
-import json  # For state saving
-
-# Initialize colorama for cross-platform colored terminal text
-colorama.init()
-
-# Your name for copyright
-COPYRIGHT_OWNER = "Harekrishna Rai"
+from colorama import Fore, Style
+from header import figlet_header
+from profile import select_profile
+from region_check import list_active_regions, check_service_in_region
+from sns_operations import get_topic_attributes, list_subscriptions, send_message, brute_force_regions, check_sns_misconfigurations
+from state import save_state, load_state
 
 regions = [
     'af-south-1', 'ap-east-1', 'ap-northeast-1', 'ap-northeast-2', 'ap-northeast-3', 'ap-south-1',
@@ -23,139 +15,6 @@ regions = [
     'eu-west-3', 'me-central-1', 'me-south-1', 'sa-east-1', 'us-east-1', 'us-east-2',
     'us-west-1', 'us-west-2'
 ]
-
-def figlet_header():
-    ascii_art = pyfiglet.figlet_format("Snare", font = "slant")
-    print(Fore.RED + ascii_art + Style.RESET_ALL)
-    print(f"{Fore.YELLOW}Copyright © {COPYRIGHT_OWNER}{Style.RESET_ALL}")
-
-def list_available_profiles():
-    profiles = []
-    config_path = os.path.expanduser('~/.aws/config')
-    if os.path.exists(config_path):
-        with open(config_path, 'r') as f:
-            for line in f:
-                if line.strip().startswith('[') and 'profile ' in line:
-                    profiles.append(line.split('profile ')[1].strip()[:-1])  # Remove the closing bracket
-    return profiles
-
-def select_profile():
-    profiles = list_available_profiles()
-    if not profiles:
-        print(f"{Fore.RED}No AWS profiles found in ~/.aws/config.{Style.RESET_ALL}")
-        return None
-    print(f"{Fore.CYAN}Available AWS Profiles:{Style.RESET_ALL}")
-    for i, profile in enumerate(profiles, 1):
-        print(f"{i}. {profile}")
-    choice = input(f"{Fore.GREEN}Select profile number (or press Enter for default): {Style.RESET_ALL}")
-    if choice == "":
-        return None  # Use default profile
-    try:
-        return profiles[int(choice) - 1]
-    except (ValueError, IndexError):
-        print(f"{Fore.RED}Invalid selection. Using default profile.{Style.RESET_ALL}")
-        return None
-
-def loading_animation():
-    animations = ['[■□□□□□□□□□]', '[■■□□□□□□□□]', '[■■■□□□□□□□]', '[■■■■□□□□□□]', '[■■■■■□□□□□]', '[■■■■■■□□□□]', '[■■■■■■■□□□]', '[■■■■■■■■□□]', '[■■■■■■■■■□]', '[■■■■■■■■■■]']
-    for i in range(20):
-        print(f"\r{animations[i % len(animations)]}", end='', flush=True)
-        time.sleep(0.1)
-
-def check_service_in_region(service, region, session):
-    try:
-        if service == 'sns':
-            client = session.client('sns', region_name=region)
-            client.list_topics()
-        elif service == 'ses':
-            client = session.client('ses', region_name=region)
-            client.list_identities()
-        print(f"{Fore.GREEN}{service.upper()} is active in {region}{Style.RESET_ALL}")
-        return True
-    except ClientError as e:
-        if e.response['Error']['Code'] == 'InvalidClientTokenId':
-            print(f"{Fore.RED}Credentials are not valid for {service.upper()} in {region}{Style.RESET_ALL}")
-        else:
-            print(f"{Fore.YELLOW}{service.upper()} is not active in {region}{Style.RESET_ALL}")
-        return False
-
-def list_active_regions(service, session):
-    active_regions = []
-    print(f"{Fore.CYAN}Checking regions for {service.upper()}:{Style.RESET_ALL}")
-    for region in regions:
-        loading_animation()
-        if check_service_in_region(service, region, session):
-            active_regions.append(region)
-    print("\n")
-    return active_regions
-
-def get_topic_attributes(session):
-    topic_arn = input(f"{Fore.GREEN}Enter the ARN of the topic to check attributes: {Style.RESET_ALL}")
-    try:
-        sns = session.client('sns')
-        attributes = sns.get_topic_attributes(TopicArn=topic_arn)
-        print(f"{Fore.CYAN}Attributes of Topic {topic_arn}:{Style.RESET_ALL}")
-        for key, value in attributes['Attributes'].items():
-            print(f"  {key}: {value}")
-    except ClientError as e:
-        print(f"{Fore.RED}Error: {e.response['Error']['Message']}{Style.RESET_ALL}")
-
-def list_subscriptions(session):
-    topic_arn = input(f"{Fore.GREEN}Enter the ARN of the topic to list subscriptions: {Style.RESET_ALL}")
-    try:
-        sns = session.client('sns')
-        subscriptions = sns.list_subscriptions_by_topic(TopicArn=topic_arn)
-        print(f"{Fore.CYAN}Subscriptions for {topic_arn}:{Style.RESET_ALL}")
-        for sub in subscriptions['Subscriptions']:
-            print(f"  - {sub['SubscriptionArn']}")
-    except ClientError as e:
-        print(f"{Fore.RED}Error: {e.response['Error']['Message']}{Style.RESET_ALL}")
-
-def send_message(session):
-    topic_arn = input(f"{Fore.GREEN}Enter the ARN of the topic to send message: {Style.RESET_ALL}")
-    message = input(f"{Fore.GREEN}Enter the message to send: {Style.RESET_ALL}")
-    try:
-        sns = session.client('sns')
-        response = sns.publish(TopicArn=topic_arn, Message=message)
-        print(f"{Fore.CYAN}Message ID: {response['MessageId']}{Style.RESET_ALL}")
-    except ClientError as e:
-        print(f"{Fore.RED}Error: {e.response['Error']['Message']}{Style.RESET_ALL}")
-
-def brute_force_regions(session):
-    print(f"{Fore.CYAN}Brute-forcing regions for SNS and SES:{Style.RESET_ALL}")
-    for region in regions:
-        loading_animation()
-        check_service_in_region('sns', region, session)
-        check_service_in_region('ses', region, session)
-    print("\n")
-
-def check_sns_misconfigurations(session):
-    print(f"{Fore.CYAN}Checking for SNS misconfigurations:{Style.RESET_ALL}")
-    sns = session.client('sns')
-    for region in regions:
-        try:
-            topics = sns.list_topics()['Topics']
-            for topic in topics:
-                loading_animation()
-                attributes = sns.get_topic_attributes(TopicArn=topic['TopicArn'])
-                policy = attributes['Attributes'].get('Policy')
-                if policy:
-                    print(f"\n{Fore.GREEN}Topic {topic['TopicArn']} has a policy:{Style.RESET_ALL}")
-                    print(policy)
-                else:
-                    print(f"\n{Fore.YELLOW}Topic {topic['TopicArn']} has no explicit policy set.{Style.RESET_ALL}")
-        except ClientError:
-            print(f"\n{Fore.RED}Error accessing topics in {region}.{Style.RESET_ALL}")
-
-def save_state(state, filename='state.json'):
-    with open(filename, 'w') as f:
-        json.dump(state, f)
-
-def load_state(filename='state.json'):
-    if os.path.exists(filename):
-        with open(filename, 'r') as f:
-            return json.load(f)
-    return None
 
 def main():
     figlet_header()

--- a/profile.py
+++ b/profile.py
@@ -1,0 +1,29 @@
+import os
+from colorama import Fore, Style
+
+def list_available_profiles():
+    profiles = []
+    config_path = os.path.expanduser('~/.aws/config')
+    if os.path.exists(config_path):
+        with open(config_path, 'r') as f:
+            for line in f:
+                if line.strip().startswith('[') and 'profile ' in line:
+                    profiles.append(line.split('profile ')[1].strip()[:-1])  # Remove the closing bracket
+    return profiles
+
+def select_profile():
+    profiles = list_available_profiles()
+    if not profiles:
+        print(f"{Fore.RED}No AWS profiles found in ~/.aws/config.{Style.RESET_ALL}")
+        return None
+    print(f"{Fore.CYAN}Available AWS Profiles:{Style.RESET_ALL}")
+    for i, profile in enumerate(profiles, 1):
+        print(f"{i}. {profile}")
+    choice = input(f"{Fore.GREEN}Select profile number (or press Enter for default): {Style.RESET_ALL}")
+    if choice == "":
+        return None  # Use default profile
+    try:
+        return profiles[int(choice) - 1]
+    except (ValueError, IndexError):
+        print(f"{Fore.RED}Invalid selection. Using default profile.{Style.RESET_ALL}")
+        return None

--- a/region_check.py
+++ b/region_check.py
@@ -1,0 +1,30 @@
+from botocore.exceptions import ClientError
+from colorama import Fore, Style
+from main import regions, loading_animation
+
+def check_service_in_region(service, region, session):
+    try:
+        if service == 'sns':
+            client = session.client('sns', region_name=region)
+            client.list_topics()
+        elif service == 'ses':
+            client = session.client('ses', region_name=region)
+            client.list_identities()
+        print(f"{Fore.GREEN}{service.upper()} is active in {region}{Style.RESET_ALL}")
+        return True
+    except ClientError as e:
+        if e.response['Error']['Code'] == 'InvalidClientTokenId':
+            print(f"{Fore.RED}Credentials are not valid for {service.upper()} in {region}{Style.RESET_ALL}")
+        else:
+            print(f"{Fore.YELLOW}{service.upper()} is not active in {region}{Style.RESET_ALL}")
+        return False
+
+def list_active_regions(service, session):
+    active_regions = []
+    print(f"{Fore.CYAN}Checking regions for {service.upper()}:{Style.RESET_ALL}")
+    for region in regions:
+        loading_animation()
+        if check_service_in_region(service, region, session):
+            active_regions.append(region)
+    print("\n")
+    return active_regions

--- a/sns_operations.py
+++ b/sns_operations.py
@@ -1,0 +1,61 @@
+from botocore.exceptions import ClientError
+from colorama import Fore, Style
+from main import regions, loading_animation
+
+def get_topic_attributes(session):
+    topic_arn = input(f"{Fore.GREEN}Enter the ARN of the topic to check attributes: {Style.RESET_ALL}")
+    try:
+        sns = session.client('sns')
+        attributes = sns.get_topic_attributes(TopicArn=topic_arn)
+        print(f"{Fore.CYAN}Attributes of Topic {topic_arn}:{Style.RESET_ALL}")
+        for key, value in attributes['Attributes'].items():
+            print(f"  {key}: {value}")
+    except ClientError as e:
+        print(f"{Fore.RED}Error: {e.response['Error']['Message']}{Style.RESET_ALL}")
+
+def list_subscriptions(session):
+    topic_arn = input(f"{Fore.GREEN}Enter the ARN of the topic to list subscriptions: {Style.RESET_ALL}")
+    try:
+        sns = session.client('sns')
+        subscriptions = sns.list_subscriptions_by_topic(TopicArn=topic_arn)
+        print(f"{Fore.CYAN}Subscriptions for {topic_arn}:{Style.RESET_ALL}")
+        for sub in subscriptions['Subscriptions']:
+            print(f"  - {sub['SubscriptionArn']}")
+    except ClientError as e:
+        print(f"{Fore.RED}Error: {e.response['Error']['Message']}{Style.RESET_ALL}")
+
+def send_message(session):
+    topic_arn = input(f"{Fore.GREEN}Enter the ARN of the topic to send message: {Style.RESET_ALL}")
+    message = input(f"{Fore.GREEN}Enter the message to send: {Style.RESET_ALL}")
+    try:
+        sns = session.client('sns')
+        response = sns.publish(TopicArn=topic_arn, Message=message)
+        print(f"{Fore.CYAN}Message ID: {response['MessageId']}{Style.RESET_ALL}")
+    except ClientError as e:
+        print(f"{Fore.RED}Error: {e.response['Error']['Message']}{Style.RESET_ALL}")
+
+def brute_force_regions(session):
+    print(f"{Fore.CYAN}Brute-forcing regions for SNS and SES:{Style.RESET_ALL}")
+    for region in regions:
+        loading_animation()
+        check_service_in_region('sns', region, session)
+        check_service_in_region('ses', region, session)
+    print("\n")
+
+def check_sns_misconfigurations(session):
+    print(f"{Fore.CYAN}Checking for SNS misconfigurations:{Style.RESET_ALL}")
+    sns = session.client('sns')
+    for region in regions:
+        try:
+            topics = sns.list_topics()['Topics']
+            for topic in topics:
+                loading_animation()
+                attributes = sns.get_topic_attributes(TopicArn=topic['TopicArn'])
+                policy = attributes['Attributes'].get('Policy')
+                if policy:
+                    print(f"\n{Fore.GREEN}Topic {topic['TopicArn']} has a policy:{Style.RESET_ALL}")
+                    print(policy)
+                else:
+                    print(f"\n{Fore.YELLOW}Topic {topic['TopicArn']} has no explicit policy set.{Style.RESET_ALL}")
+        except ClientError:
+            print(f"\n{Fore.RED}Error accessing topics in {region}.{Style.RESET_ALL}")

--- a/state.py
+++ b/state.py
@@ -1,0 +1,12 @@
+import json
+import os
+
+def save_state(state, filename='state.json'):
+    with open(filename, 'w') as f:
+        json.dump(state, f)
+
+def load_state(filename='state.json'):
+    if os.path.exists(filename):
+        with open(filename, 'r') as f:
+            return json.load(f)
+    return None


### PR DESCRIPTION
Add state-saving functionality to `main.py` to handle interruptions.

* **State Saving Functions**
  - Add `save_state` function to serialize and save the current state and results to a file using JSON format.
  - Add `load_state` function to deserialize and load the saved state and results from a file using JSON format.

* **Main Loop Modifications**
  - Modify the main loop to periodically call `save_state` and to call `load_state` at the start.
  - Add logic to resume from the last saved state if interrupted.

* **Dependencies**
  - Add `json` library to `requirements.txt`.

----

Refactor `main.py` by moving functions to separate files based on their tasks and add a GitHub Actions workflow to generate binary files for all platforms.

* **Refactor Functions:**
  - Move `figlet_header()` to `header.py`.
  - Move `list_available_profiles()` and `select_profile()` to `profile.py`.
  - Move `loading_animation()` to `animation.py`.
  - Move `check_service_in_region()` and `list_active_regions()` to `region_check.py`.
  - Move `get_topic_attributes()`, `list_subscriptions()`, `send_message()`, `brute_force_regions()`, and `check_sns_misconfigurations()` to `sns_operations.py`.
  - Move `save_state()` and `load_state()` to `state.py`.
  - Update `main.py` to import functions from the new files and retain only the `main()` function.

* **Add GitHub Actions Workflow:**
  - Add `build.yml` in `.github/workflows/` to build the project for Windows, macOS, and Linux platforms.