### PR TITLE
Modify the workflow for pushing the binaries created to the release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
           python setup.py install
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: snare-binaries
           path: dist/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build and Release
 
 on:
   push:
@@ -32,3 +32,34 @@ jobs:
       - name: Build project
         run: |
           python setup.py install
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: snare-binaries
+          path: dist/*
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: snare-binaries
+
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: |
+            Release of Snare binaries.
+          draft: false
+          prerelease: false
+          files: dist/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,10 @@ jobs:
         with:
           name: snare-binaries-${{ github.run_id }}
           path: dist/*
+          if-no-files-found: warn
+          compression-level: 6
+          overwrite: false
+          include-hidden-files: false
 
   release:
     needs: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: snare-binaries
+          name: snare-binaries-${{ github.run_id }}
           path: dist/*
 
   release:
@@ -49,7 +49,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v2
         with:
-          name: snare-binaries
+          name: snare-binaries-${{ github.run_id }}
 
       - name: Create GitHub Release
         uses: actions/create-release@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
           python setup.py install
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: snare-binaries
           path: dist/*


### PR DESCRIPTION
Add steps to push binaries to release in the GitHub Actions workflow.

* Modify the workflow name to "Build and Release".
* Add a step to upload the binaries as an artifact after the build.
* Add a new job `release` that depends on the `build` job.
* Use `actions/upload-artifact@v2` to upload the binaries.
* Use `actions/create-release@v1` to create a release and upload the binaries.
* Trigger the `release` job only on successful completion of the `build` job.

